### PR TITLE
Ignore unknown release attributes during sync

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1077,7 +1077,7 @@ class Project < ApplicationRecord
 
     releases.each do |release|
       r = Release.find_or_create_by(project_id: id, uuid: release['uuid'])
-      r.update(release.except('release_url', 'immutable'))
+      r.update(Release.sync_attributes(release))
     end
   end
 end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -1,4 +1,9 @@
 class Release < ApplicationRecord
+  LOCALLY_MANAGED_ATTRIBUTES = %w[id project_id created_at updated_at].freeze
+
   belongs_to :project
-  
+
+  def self.sync_attributes(attributes)
+    attributes.stringify_keys.slice(*(attribute_names - LOCALLY_MANAGED_ATTRIBUTES))
+  end
 end

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -13,9 +13,10 @@ class ProjectTest < ActiveSupport::TestCase
     assert_equal 'https://github.com/foo/bar', repo_url
   end
 
-  test "sync_releases ignores unknown attributes from api" do
+  test "sync_releases ignores unknown and locally managed attributes" do
     releases_url = 'https://repos.ecosyste.ms/api/v1/hosts/GitHub/repositories/user/project/releases'
     project = create(:project)
+    other_project = create(:project)
     project.repository['releases_url'] = releases_url
 
     payload = [{
@@ -33,7 +34,8 @@ class ProjectTest < ActiveSupport::TestCase
       'html_url' => 'https://example.com/release',
       'last_synced_at' => '2026-01-01T00:00:00Z',
       'release_url' => 'https://example.com/api/release',
-      'immutable' => true
+      'immutable' => true,
+      'project_id' => other_project.id
     }]
 
     stub_request(:get, "#{releases_url}?per_page=1000")
@@ -43,6 +45,8 @@ class ProjectTest < ActiveSupport::TestCase
       project.sync_releases
     end
 
-    assert_equal 'v1.0.0', project.releases.first.tag_name
+    release = project.releases.first
+    assert_equal 'v1.0.0', release.tag_name
+    assert_equal project.id, release.project_id
   end
 end


### PR DESCRIPTION
Filters release API payloads through the `Release` schema before updating records, so new upstream fields such as `immutable` are ignored.

Keeps `id`, `project_id`, `created_at`, and `updated_at` locally managed, with regression coverage for unknown and locally managed attributes.